### PR TITLE
Ars Alt Recipes work

### DIFF
--- a/kubejs/server_scripts/mods/ars_nouveau.js
+++ b/kubejs/server_scripts/mods/ars_nouveau.js
@@ -1,0 +1,26 @@
+ServerEvents.recipes(event =>{
+    //Steel Block alt recipe
+    event.recipes.ars_nouveau.enchanting_apparatus(
+        //Inputs
+        [
+            '#minecraft:coals',
+            'ars_nouveau:fire_essence'
+        ],
+            'minecraft:iron_block', //Reagent Item (goes into the enchanting apparatus itself)
+            'thermal:steel_block',  //Output Item
+            2500,                   //Source required (One Jar = 10000)
+    )
+    //Basic Machine Frame alt recipe
+    event.recipes.ars_nouveau.enchanting_apparatus(
+        [
+            '#ad_astra:steel_plates',
+            '#ad_astra:steel_plates',
+            '#createaddition:spools',
+            '#forge:storage_blocks/silicon',
+            'ars_nouveau:manipulation_essence'
+        ],
+            'industrialforegoing:machine_frame_pity',
+            '3x energizedpower:basic_machine_frame',
+            10000,
+    )
+})

--- a/manifest.json
+++ b/manifest.json
@@ -1169,6 +1169,11 @@
             "fileID": 5712546,
             "projectID": 260912,
             "required": true
+        },
+        {
+            "fileID": 4920407,
+            "projectID": 833926,
+            "required": true
         }
     ]
 }


### PR DESCRIPTION
- Adds alt recipes for Steel blocks and Basic Machine Frames, using Ars' Enchanting Apparatus
- Adds KubeJS Ars Nouveau mod